### PR TITLE
Expose `is_unique` and `is_primary` metadata flags on `%Endo.Index{}`

### DIFF
--- a/lib/endo/adapters/postgres.ex
+++ b/lib/endo/adapters/postgres.ex
@@ -14,6 +14,7 @@ defmodule Endo.Adapters.Postgres do
   alias Endo.Adapters.Postgres.Column
   alias Endo.Adapters.Postgres.Index
   alias Endo.Adapters.Postgres.PgClass
+  alias Endo.Adapters.Postgres.PgIndex
   alias Endo.Adapters.Postgres.Table
   alias Endo.Adapters.Postgres.TableConstraint
 
@@ -68,10 +69,14 @@ defmodule Endo.Adapters.Postgres do
   end
 
   def to_endo(%Index{} = index) do
+    metadata = index.pg_index || %PgIndex{}
+
     %Endo.Index{
       adapter: __MODULE__,
       name: index.name,
-      columns: index.columns
+      columns: index.columns,
+      is_primary: metadata.indisprimary,
+      is_unique: metadata.indisunique
     }
   end
 end

--- a/lib/endo/adapters/postgres/index.ex
+++ b/lib/endo/adapters/postgres/index.ex
@@ -1,5 +1,5 @@
 defmodule Endo.Adapters.Postgres.Index do
   @moduledoc false
   @type t :: %__MODULE__{}
-  defstruct [:columns, :name]
+  defstruct [:columns, :name, :pg_index]
 end

--- a/lib/endo/adapters/postgres/pg_class.ex
+++ b/lib/endo/adapters/postgres/pg_class.ex
@@ -77,11 +77,12 @@ defmodule Endo.Adapters.Postgres.PgClass do
           on: pg_attribute.attrelid == self.oid,
           as: :pg_attribute,
           where: pg_attribute.attnum in pg_index.indkey,
-          group_by: [self.oid, self.relname, pg_class.relname],
+          group_by: [self.oid, self.relname, pg_class.relname, pg_index.indexrelid],
           select: %{
             __struct__: Index,
             name: pg_class.relname,
-            columns: fragment("ARRAY_AGG(?)", pg_attribute.attname)
+            columns: fragment("ARRAY_AGG(?)", pg_attribute.attname),
+            pg_index: pg_index
           }
         )
 

--- a/lib/endo/index.ex
+++ b/lib/endo/index.ex
@@ -1,5 +1,5 @@
 defmodule Endo.Index do
   @moduledoc "Index metadata for a given table's indexes"
   @type t :: %__MODULE__{}
-  defstruct [:adapter, :name, columns: []]
+  defstruct [:adapter, :name, is_primary: false, is_unique: false, columns: []]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Endo.MixProject do
   def project do
     [
       app: :endo,
-      version: "0.1.8",
+      version: "0.1.9",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mix.exs
+++ b/mix.exs
@@ -44,6 +44,9 @@ defmodule Endo.MixProject do
 
   defp description() do
     """
+    Endo is a library containing database schema reflection APIs for your applications, as
+    well as implementations of queryable schemas to facilitate custom database reflection
+    via Ecto.
     """
   end
 

--- a/test/endo_test.exs
+++ b/test/endo_test.exs
@@ -242,5 +242,23 @@ defmodule EndoTest do
       refute is_nil(ctx.find.(tables, "accounts"))
       refute is_nil(ctx.find.(tables, "orgs"))
     end
+
+    test "index metadata contains flags `is_unique` and `is_primary`", ctx do
+      assert tables = Endo.list_tables(Test.Postgres.Repo)
+
+      assert %Endo.Table{} = accounts = ctx.find.(tables, "accounts")
+
+      # Account IDs are both unique and also the primary key of the table
+      assert %{is_primary: true, is_unique: true} =
+               Enum.find(accounts.indexes, &(&1.columns == ["id"]))
+
+      # Account emails are unique, but not the primary key of the table
+      assert %{is_primary: false, is_unique: true} =
+               Enum.find(accounts.indexes, &(&1.columns == ["email"]))
+
+      # Account timestamps are neither unique nor the primary key of the table
+      assert %{is_primary: false, is_unique: false} =
+               Enum.find(accounts.indexes, &(&1.columns == ["updated_at"]))
+    end
   end
 end


### PR DESCRIPTION
Prior to this PR, Endo indexes looked like the following struct:

```elixir
%Endo.Index{
  adapter: Endo.Adapters.Postgres,
  columns: ["username"],
  name: "accounts_username_index"
}
```

It wasn't possible to ascertain whether or not an index was primary, or unique, which happens to be useful metadata to surface to the caller.

This PR amends the query we use to collate indexes to surface this metadata and expose it out of the Postgres adapter, so now, the above index looks like:

```elixir
%Endo.Index{
  adapter: Endo.Adapters.Postgres,
  columns: ["username"],
  is_primary: false,
  is_unique: true,
  name: "accounts_username_index"
}
```
