### PR TITLE
END 003/allow schema discovery

### DIFF
--- a/lib/endo.ex
+++ b/lib/endo.ex
@@ -111,9 +111,9 @@ defmodule Endo do
   end
 
   defp list_tables(Ecto.Adapters.Postgres, repo, filters) do
-    repo
-    |> Postgres.list_tables(filters)
-    |> Enum.map(&Postgres.to_endo/1)
+    for table <- Postgres.list_tables(repo, filters) do
+      Postgres.to_endo(table, repo.config())
+    end
   end
 
   defp list_tables(adapter, _repo, _filters) do

--- a/lib/endo.ex
+++ b/lib/endo.ex
@@ -97,6 +97,25 @@ defmodule Endo do
   alias Endo.Adapters.Postgres
 
   @doc """
+  Given an Ecto Repo and a table name, tries to return an Endo Table or nil if said table does
+  not exist.
+
+  Internally delegates to `list_tables/2` with the `table_name` option set.
+  See `list_tables/2` for more information.
+  """
+  @spec get_table(repo :: module(), table_name :: String.t(), filters :: Keyword.t()) ::
+          Endo.Table.t() | nil
+  def get_table(repo, table_name, filters \\ []) when is_binary(table_name) do
+    case list_tables(repo, Keyword.put(filters, :table_name, table_name)) do
+      [%Endo.Table{} = endo_table] ->
+        endo_table
+
+      [] ->
+        nil
+    end
+  end
+
+  @doc """
   Given an Ecto Repo, returns a list of all tables, columns, associations, and indexes.
   Takes an optional keyword list of filters which filter said tables down to given constraints.
   """

--- a/lib/endo.ex
+++ b/lib/endo.ex
@@ -123,4 +123,12 @@ defmodule Endo do
       Given: #{inspect(adapter)}
       """
   end
+
+  @doc """
+  Given a list of Endo Tables or a single Endo Table, tries to load the application-specific Ecto Schemas
+  See `Endo.Schema.load/1` for more information.
+  """
+  @spec load_schemas(Endo.Table.t()) :: Endo.Table.t()
+  @spec load_schemas([Endo.Table.t()]) :: [Endo.Table.t()]
+  defdelegate load_schemas(endo_table_or_tables), to: Endo.Schema, as: :load
 end

--- a/lib/endo/schema.ex
+++ b/lib/endo/schema.ex
@@ -1,0 +1,63 @@
+defmodule Endo.Schema do
+  @moduledoc "Utility module for discovering Ecto Schema implementations for a given Endo Table"
+
+  defmodule NotLoaded do
+    @moduledoc false
+
+    @type t :: %__MODULE__{}
+
+    @enforce_keys [:table]
+    defstruct [:table, :otp_app]
+  end
+
+  @spec load([Endo.Table.t()]) :: [Endo.Table.t()]
+  @spec load(Endo.Table.t()) :: Endo.Table.t()
+
+  @doc """
+  Given a list of Endo Tables, tries to load their schemas in their corresponding OTP App.
+
+  All Endo Table structs contain metadata about which OTP app a given Repo belongs to. This information is used
+  to load all Elixir modules that `use Ecto.Schema`.
+
+  With this list, we match up any schemas to tables that exist; though it is important to note that not all
+  Endo Tables will necessarily have a corresponding Ecto Schema module defined for it.
+
+  In this case, the `schemas` key of an Endo Table will be an empty list.
+
+  It is also possible for multiple Ecto Schemas to exist for a single underlying database tables, thus, any discovered
+  results will be accumulated and returned as a list of modules per Endo Table.
+  """
+  def load([%Endo.Table{} | _rest] = endo_tables) do
+    unless Enum.all?(endo_tables, &is_struct(&1, Endo.Table)) do
+      raise ArgumentError,
+            "All entities in list must be of type `Endo.Table.t()`. Got: #{inspect(endo_tables)}"
+    end
+
+    {unloaded_endo_tables, loaded_endo_tables} =
+      Enum.split_with(endo_tables, &is_struct(&1.schemas, NotLoaded))
+
+    loaded_endo_tables ++
+      (unloaded_endo_tables
+       |> Enum.group_by(& &1.schemas.otp_app)
+       |> Enum.flat_map(fn {otp_app, endo_tables} ->
+         app_schemas = app_schemas(otp_app)
+         Enum.map(endo_tables, &do_load(&1, app_schemas))
+       end))
+  end
+
+  def load(%Endo.Table{schemas: %NotLoaded{otp_app: otp_app}} = endo_table) do
+    do_load(endo_table, app_schemas(otp_app))
+  end
+
+  defp do_load(%Endo.Table{schemas: %NotLoaded{table: table}} = endo_table, app_schemas) do
+    %Endo.Table{endo_table | schemas: Map.get(app_schemas, table, [])}
+  end
+
+  defp app_schemas(otp_app) when is_atom(otp_app) do
+    {:ok, modules} = :application.get_key(otp_app, :modules)
+
+    modules
+    |> Enum.filter(&function_exported?(&1, :__schema__, 1))
+    |> Enum.group_by(& &1.__schema__(:source))
+  end
+end

--- a/lib/endo/table.ex
+++ b/lib/endo/table.ex
@@ -1,5 +1,5 @@
 defmodule Endo.Table do
   @moduledoc "Table metadata returned by Endo"
   @type t :: %__MODULE__{}
-  defstruct [:adapter, :name, columns: [], associations: [], indexes: []]
+  defstruct [:adapter, :name, :schemas, columns: [], associations: [], indexes: []]
 end

--- a/lib/test/postgres/org.ex
+++ b/lib/test/postgres/org.ex
@@ -1,0 +1,10 @@
+if Mix.env() == :test do
+  defmodule Test.Postgres.Org do
+    @moduledoc false
+
+    use Ecto.Schema
+
+    schema "orgs" do
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Endo.MixProject do
   def project do
     [
       app: :endo,
-      version: "0.1.9",
+      version: "0.1.10",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
- Add functionality to allow Endo to discover corresponding Ecto Schema modules
    * When loading Endo Tables from the database, you can pass them into `Endo.load_schemas/1` which will act similarly to `Ecto.Repo.preload/2` in that it will replace a `schemas: %Endo.Schema.NotLoaded{}` placeholder struct with a list of Ecto Schemas which point to the given table.
    * Takes either a list or Endo Tables or a single Endo Table.
- Add helper functionality to get table by name explicitly (`Endo.get_table/3`)

See unit tests and docs
