### PR TITLE
Surface association `from_table_name`, `to_table_name`, `from_column_name`, `to_column_name` metadata

### DIFF
--- a/lib/endo/adapters/postgres.ex
+++ b/lib/endo/adapters/postgres.ex
@@ -20,7 +20,7 @@ defmodule Endo.Adapters.Postgres do
 
   @spec list_tables(repo :: module(), opts :: Keyword.t()) :: [Table.t()]
   def list_tables(repo, opts \\ []) when is_atom(repo) do
-    preloads = [:columns, table_constraints: :constraint_column_usage]
+    preloads = [:columns, table_constraints: [:key_column_usage, :constraint_column_usage]]
 
     preload_indexes = fn %Table{table_name: name} = table ->
       indexes = PgClass.query(collate_indexes: true, relname: name)
@@ -70,7 +70,11 @@ defmodule Endo.Adapters.Postgres do
     %Endo.Association{
       adapter: __MODULE__,
       name: constraint.constraint_name,
-      type: constraint.constraint_column_usage.table_name
+      type: constraint.constraint_column_usage.table_name,
+      from_table_name: constraint.key_column_usage.table_name,
+      to_table_name: constraint.constraint_column_usage.table_name,
+      from_column_name: constraint.key_column_usage.column_name,
+      to_column_name: constraint.constraint_column_usage.column_name
     }
   end
 

--- a/lib/endo/association.ex
+++ b/lib/endo/association.ex
@@ -1,5 +1,13 @@
 defmodule Endo.Association do
   @moduledoc "Association metadata for a given table's associations"
   @type t :: %__MODULE__{}
-  defstruct [:adapter, :name, :type]
+  defstruct [
+    :adapter,
+    :name,
+    :type,
+    :from_table_name,
+    :to_table_name,
+    :from_column_name,
+    :to_column_name
+  ]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Endo.MixProject do
   def project do
     [
       app: :endo,
-      version: "0.1.10",
+      version: "0.1.11",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/endo_test.exs
+++ b/test/endo_test.exs
@@ -98,18 +98,36 @@ defmodule EndoTest do
       # Association metadata is also surfaced:
       assert Enum.count(accounts_orgs.associations) == 2
 
-      assert %Endo.Association{name: "accounts_orgs_account_id_fkey", type: "accounts"} =
-               ctx.find.(accounts_orgs.associations, "accounts_orgs_account_id_fkey")
+      assert %Endo.Association{
+               name: "accounts_orgs_account_id_fkey",
+               type: "accounts",
+               from_table_name: "accounts_orgs",
+               to_table_name: "accounts",
+               from_column_name: "account_id",
+               to_column_name: "id"
+             } = ctx.find.(accounts_orgs.associations, "accounts_orgs_account_id_fkey")
 
-      assert %Endo.Association{name: "accounts_orgs_org_id_fkey", type: "orgs"} =
-               ctx.find.(accounts_orgs.associations, "accounts_orgs_org_id_fkey")
+      assert %Endo.Association{
+               name: "accounts_orgs_org_id_fkey",
+               type: "orgs",
+               from_table_name: "accounts_orgs",
+               to_table_name: "orgs",
+               from_column_name: "org_id",
+               to_column_name: "id"
+             } = ctx.find.(accounts_orgs.associations, "accounts_orgs_org_id_fkey")
 
       # Of course, individual tables might represent a many-to-one association. This likewise is
       # surfaced:
       assert Enum.count(repos.associations) == 1
 
-      assert %Endo.Association{name: "repos_account_id_fkey", type: "accounts"} =
-               ctx.find.(repos.associations, "repos_account_id_fkey")
+      assert %Endo.Association{
+               name: "repos_account_id_fkey",
+               type: "accounts",
+               from_table_name: "repos",
+               to_table_name: "accounts",
+               from_column_name: "account_id",
+               to_column_name: "id"
+             } = ctx.find.(repos.associations, "repos_account_id_fkey")
     end
 
     test "lists tables and metadata for all tables with column" do


### PR DESCRIPTION
Updates listing associations on postgres tables to be able to surface metadata about what table/column the source of any given constraint is.
