### PR TITLE
END 005/expose postgres metadata

### DIFF
--- a/lib/endo/adapters/postgres/metadata.ex
+++ b/lib/endo/adapters/postgres/metadata.ex
@@ -1,0 +1,37 @@
+defmodule Endo.Adapters.Postgres.Metadata do
+  @moduledoc "Utility module for taking a Postgres table and exposing adapter specific metadata to Endo"
+  # coveralls-ignore-start
+
+  alias Endo.Adapters.Postgres.PgClass
+  alias Endo.Adapters.Postgres.Table
+
+  @spec derive!(Table.t()) :: Endo.Metadata.Postgres.t()
+  def derive!(%Table{pg_class: pg_class}) do
+    %Endo.Metadata.Postgres{
+      replica_identity: replica_identity(pg_class),
+      kind: kind(pg_class),
+      has_triggers: pg_class.relhastriggers,
+      is_populated: pg_class.relispopulated,
+      is_partitioned: pg_class.relispartition,
+      pg_class: pg_class
+    }
+  end
+
+  defp replica_identity(%PgClass{relreplident: "d"}), do: "DEFAULT"
+  defp replica_identity(%PgClass{relreplident: "n"}), do: "NOTHING"
+  defp replica_identity(%PgClass{relreplident: "f"}), do: "FULL"
+  defp replica_identity(%PgClass{relreplident: "i"}), do: "INDEX"
+  defp replica_identity(%PgClass{relreplident: _}), do: nil
+
+  defp kind(%PgClass{relkind: "r"}), do: "ordinary table"
+  defp kind(%PgClass{relkind: "i"}), do: "index"
+  defp kind(%PgClass{relkind: "S"}), do: "sequence"
+  defp kind(%PgClass{relkind: "t"}), do: "TOAST table"
+  defp kind(%PgClass{relkind: "v"}), do: "view"
+  defp kind(%PgClass{relkind: "m"}), do: "materialized view"
+  defp kind(%PgClass{relkind: "c"}), do: "composite type"
+  defp kind(%PgClass{relkind: "f"}), do: "foreign table"
+  defp kind(%PgClass{relkind: "p"}), do: "partitioned table"
+  defp kind(%PgClass{relkind: "I"}), do: "partitioned index"
+  defp kind(%PgClass{relkind: _}), do: nil
+end

--- a/lib/endo/adapters/postgres/table.ex
+++ b/lib/endo/adapters/postgres/table.ex
@@ -47,6 +47,7 @@ defmodule Endo.Adapters.Postgres.Table do
     )
 
     field(:indexes, :map, virtual: true)
+    field(:pg_class, :map, virtual: true)
   end
 
   @impl Endo.Queryable

--- a/lib/endo/metadata.ex
+++ b/lib/endo/metadata.ex
@@ -1,0 +1,22 @@
+defmodule Endo.Metadata do
+  @moduledoc "Utility module for surfacing adapter specific metadata"
+
+  defmodule NotLoaded do
+    @moduledoc false
+    @type t :: %__MODULE__{}
+    defstruct []
+  end
+
+  defmodule Postgres do
+    @moduledoc false
+    @type t :: %__MODULE__{}
+    defstruct [
+      :replica_identity,
+      :kind,
+      :has_triggers,
+      :is_populated,
+      :is_partitioned,
+      :pg_class
+    ]
+  end
+end

--- a/lib/endo/schema.ex
+++ b/lib/endo/schema.ex
@@ -5,8 +5,6 @@ defmodule Endo.Schema do
     @moduledoc false
 
     @type t :: %__MODULE__{}
-
-    @enforce_keys [:table]
     defstruct [:table, :otp_app]
   end
 

--- a/lib/endo/table.ex
+++ b/lib/endo/table.ex
@@ -1,5 +1,13 @@
 defmodule Endo.Table do
-  @moduledoc "Table metadata returned by Endo"
+  @moduledoc "Table metadata returned by Endo."
   @type t :: %__MODULE__{}
-  defstruct [:adapter, :name, :schemas, columns: [], associations: [], indexes: []]
+  defstruct [
+    :adapter,
+    :name,
+    columns: [],
+    associations: [],
+    indexes: [],
+    schemas: %Endo.Schema.NotLoaded{},
+    metadata: %Endo.Metadata.NotLoaded{}
+  ]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Endo.MixProject do
   def project do
     [
       app: :endo,
-      version: "0.1.11",
+      version: "0.1.12",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Exposes Postgres table metadata so that we have access to things such as `replica_identity` which is useful for CI checks.
