### PR TITLE
Extend postgres metadata to expose table sizes

### DIFF
--- a/lib/endo/adapters/postgres.ex
+++ b/lib/endo/adapters/postgres.ex
@@ -22,7 +22,6 @@ defmodule Endo.Adapters.Postgres do
 
   @spec list_tables(repo :: module(), opts :: Keyword.t()) :: [Table.t()]
   def list_tables(repo, opts \\ []) when is_atom(repo) do
-    import Ecto.Query
     preloads = [:columns, table_constraints: [:key_column_usage, :constraint_column_usage]]
 
     derive_preloads = fn %Table{table_name: name} = table ->

--- a/lib/endo/adapters/postgres/metadata.ex
+++ b/lib/endo/adapters/postgres/metadata.ex
@@ -17,7 +17,11 @@ defmodule Endo.Adapters.Postgres.Metadata do
       table_size: size.table_size,
       relation_size: size.relation_size,
       toast_size: size.toast_size,
-      index_size: size.index_size
+      index_size: size.index_size,
+      table_size_pretty: size.table_size_pretty,
+      relation_size_pretty: size.relation_size_pretty,
+      toast_size_pretty: size.toast_size_pretty,
+      index_size_pretty: size.index_size_pretty
     }
   end
 

--- a/lib/endo/adapters/postgres/metadata.ex
+++ b/lib/endo/adapters/postgres/metadata.ex
@@ -6,14 +6,18 @@ defmodule Endo.Adapters.Postgres.Metadata do
   alias Endo.Adapters.Postgres.Table
 
   @spec derive!(Table.t()) :: Endo.Metadata.Postgres.t()
-  def derive!(%Table{pg_class: pg_class}) do
+  def derive!(%Table{pg_class: pg_class, size: size}) do
     %Endo.Metadata.Postgres{
       replica_identity: replica_identity(pg_class),
       kind: kind(pg_class),
       has_triggers: pg_class.relhastriggers,
       is_populated: pg_class.relispopulated,
       is_partitioned: pg_class.relispartition,
-      pg_class: pg_class
+      pg_class: pg_class,
+      table_size: size.table_size,
+      relation_size: size.relation_size,
+      toast_size: size.toast_size,
+      index_size: size.index_size
     }
   end
 

--- a/lib/endo/adapters/postgres/size.ex
+++ b/lib/endo/adapters/postgres/size.ex
@@ -11,15 +11,28 @@ defmodule Endo.Adapters.Postgres.Size do
           fragment(
             """
             SELECT
-              pg_size_pretty(pg_table_size(?::text::regclass)) as table_size,
-              pg_size_pretty(pg_relation_size(?::text::regclass)) as relation_size,
-              pg_size_pretty(pg_indexes_size(?::text::regclass)) as index_size,
+              pg_table_size(?::text::regclass) as table_size,
+              pg_size_pretty(pg_table_size(?::text::regclass)) as table_size_pretty,
+              pg_relation_size(?::text::regclass) as relation_size,
+              pg_size_pretty(pg_relation_size(?::text::regclass)) as relation_size_pretty,
+              pg_indexes_size(?::text::regclass) as index_size,
+              pg_size_pretty(pg_indexes_size(?::text::regclass)) as index_size_pretty,
+              pg_total_relation_size(?::text::regclass) -
+                pg_relation_size(?::text::regclass) -
+                pg_indexes_size(?::text::regclass)
+              as toast_size,
               pg_size_pretty(
                 pg_total_relation_size(?::text::regclass) -
                 pg_relation_size(?::text::regclass) -
                 pg_indexes_size(?::text::regclass)
-              ) as toast_size
+              ) as toast_size_pretty
             """,
+            ^relname,
+            ^relname,
+            ^relname,
+            ^relname,
+            ^relname,
+            ^relname,
             ^relname,
             ^relname,
             ^relname,
@@ -33,7 +46,11 @@ defmodule Endo.Adapters.Postgres.Size do
         table_size: virtual_table.table_size,
         relation_size: virtual_table.relation_size,
         toast_size: virtual_table.toast_size,
-        index_size: virtual_table.index_size
+        index_size: virtual_table.index_size,
+        table_size_pretty: virtual_table.table_size_pretty,
+        relation_size_pretty: virtual_table.relation_size_pretty,
+        toast_size_pretty: virtual_table.toast_size_pretty,
+        index_size_pretty: virtual_table.index_size_pretty
       }
     )
   end

--- a/lib/endo/adapters/postgres/size.ex
+++ b/lib/endo/adapters/postgres/size.ex
@@ -1,0 +1,40 @@
+defmodule Endo.Adapters.Postgres.Size do
+  @moduledoc false
+
+  import Ecto.Query
+
+  @spec query([{:relname, String.t()}]) :: Ecto.Queryable.t()
+  def query(relname: relname) do
+    select(
+      with_cte("virtual_table", "virtual_table",
+        as:
+          fragment(
+            """
+            SELECT
+              pg_size_pretty(pg_table_size(?::text::regclass)) as table_size,
+              pg_size_pretty(pg_relation_size(?::text::regclass)) as relation_size,
+              pg_size_pretty(pg_indexes_size(?::text::regclass)) as index_size,
+              pg_size_pretty(
+                pg_total_relation_size(?::text::regclass) -
+                pg_relation_size(?::text::regclass) -
+                pg_indexes_size(?::text::regclass)
+              ) as toast_size
+            """,
+            ^relname,
+            ^relname,
+            ^relname,
+            ^relname,
+            ^relname,
+            ^relname
+          )
+      ),
+      [virtual_table],
+      %{
+        table_size: virtual_table.table_size,
+        relation_size: virtual_table.relation_size,
+        toast_size: virtual_table.toast_size,
+        index_size: virtual_table.index_size
+      }
+    )
+  end
+end

--- a/lib/endo/adapters/postgres/table.ex
+++ b/lib/endo/adapters/postgres/table.ex
@@ -48,6 +48,7 @@ defmodule Endo.Adapters.Postgres.Table do
 
     field(:indexes, :map, virtual: true)
     field(:pg_class, :map, virtual: true)
+    field(:size, :map, virtual: true)
   end
 
   @impl Endo.Queryable

--- a/lib/endo/metadata.ex
+++ b/lib/endo/metadata.ex
@@ -20,7 +20,11 @@ defmodule Endo.Metadata do
       :table_size,
       :relation_size,
       :index_size,
-      :toast_size
+      :toast_size,
+      :table_size_pretty,
+      :relation_size_pretty,
+      :index_size_pretty,
+      :toast_size_pretty
     ]
   end
 end

--- a/lib/endo/metadata.ex
+++ b/lib/endo/metadata.ex
@@ -16,7 +16,11 @@ defmodule Endo.Metadata do
       :has_triggers,
       :is_populated,
       :is_partitioned,
-      :pg_class
+      :pg_class,
+      :table_size,
+      :relation_size,
+      :index_size,
+      :toast_size
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Endo.MixProject do
   def project do
     [
       app: :endo,
-      version: "0.1.12",
+      version: "0.1.13",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/endo_test.exs
+++ b/test/endo_test.exs
@@ -314,6 +314,16 @@ defmodule EndoTest do
       assert tables = Endo.list_tables(Test.Postgres.Repo)
 
       for table <- tables, size <- [:table_size, :relation_size, :toast_size, :index_size] do
+        assert is_integer(Map.get(table.metadata, size))
+      end
+
+      for table <- tables,
+          size <- [
+            :table_size_pretty,
+            :relation_size_pretty,
+            :toast_size_pretty,
+            :index_size_pretty
+          ] do
         # Actual values are, of course, dynamic based on the size of the table.
         # Just assert that we get the number of kilobytes or bytes returned and trust that
         # this scales up into the gigabytes and such accordingly.

--- a/test/endo_test.exs
+++ b/test/endo_test.exs
@@ -309,6 +309,18 @@ defmodule EndoTest do
       assert %{is_primary: false, is_unique: false} =
                Enum.find(accounts.indexes, &(&1.columns == ["updated_at"]))
     end
+
+    test "size metadata is returned alongside fetching tables" do
+      assert tables = Endo.list_tables(Test.Postgres.Repo)
+
+      for table <- tables, size <- [:table_size, :relation_size, :toast_size, :index_size] do
+        # Actual values are, of course, dynamic based on the size of the table.
+        # Just assert that we get the number of kilobytes or bytes returned and trust that
+        # this scales up into the gigabytes and such accordingly.
+        value = Map.get(table.metadata, size)
+        assert value =~ "bytes" or value =~ "kB"
+      end
+    end
   end
 
   describe "load_tables/1" do

--- a/test/endo_test.exs
+++ b/test/endo_test.exs
@@ -311,7 +311,9 @@ defmodule EndoTest do
     end
 
     test "size metadata is returned alongside fetching tables" do
-      assert tables = Endo.list_tables(Test.Postgres.Repo)
+      assert tables =
+               Endo.list_tables(Test.Postgres.Repo)
+               |> IO.inspect()
 
       for table <- tables, size <- [:table_size, :relation_size, :toast_size, :index_size] do
         assert is_integer(Map.get(table.metadata, size))


### PR DESCRIPTION
This PR extends our `Endo.Metadata.Postgres.t()` struct to expose various table sizes.

Please reference the below image for all the sizes which can now be derived:
![image](https://user-images.githubusercontent.com/15597865/227529608-c791a300-9ad3-42c1-877c-8c0a64993bc7.png)

This will enable Endo users to optimize/prioritise code based on underlying table sizes, as well as potentially allow better estimation of long running tasks/activities.

See exposed metadata below:
![image](https://user-images.githubusercontent.com/15597865/227530543-a75740f8-07c2-48d0-b219-99df3cb7caf1.png)
