### PR TITLE
END 007/covering indexes

### DIFF
--- a/lib/endo.ex
+++ b/lib/endo.ex
@@ -60,6 +60,11 @@ defmodule Endo do
     components and order.
   - `without_index`, instructs Endo to only return tables without indexes on the given column or columns.
     Likewise, compound indexes must exactly match the given ones components and order.
+  - `with_index_covering`, instructs Endo to only return tables with an index which covers the given
+    column(s). An index covering a given column(s) is defined as whether or not there exists a single index
+    or composite index which contains the given column(s) regardless of ordering.
+  - `without_index_covering`, instructs Endo to only return tables without an index which covers the given
+    column(s). The same caveats as the above option apply.
 
   Additionally, adapters are free to implement custom filters. The `Endo.Adapters.Postgres` adapter
   forwards any filters not matching the above list directly to direct SQL queries against the base
@@ -89,8 +94,13 @@ defmodule Endo do
   # Returns list of tables defining a relation to `cars`, without an index on said column
 
   Endo.list_tables(MyApp.Repo, with_index: ["org_id", "location_id", "patient_id"])
-  # Returns list of tables defining a *compound index* on `(org_id, location_id, patient_id)`
+  # Returns list of tables defining a *composite index* on `(org_id, location_id, patient_id)`
   # Tables containing the same index in a different order, or a partial match will not be returned.
+
+  Endo.list_tables(MyApp.Repo, with_index_covering: "org_id")
+  # Returns list of tables defining any index which includes `org_id` (exact matches, or there exists
+  # some composite index where `org_id` is a member).
+  # Ordering does not matter.
   ```
 
   ## Adapter-specific metadata

--- a/lib/endo/adapters/postgres/table.ex
+++ b/lib/endo/adapters/postgres/table.ex
@@ -85,6 +85,18 @@ defmodule Endo.Adapters.Postgres.Table do
 
         from(query, where: not exists(indexes_query))
 
+      {:with_index_covering, columns}, query ->
+        indexes_query =
+          PgClass.query(subquery: true, collate_indexes: true, index_covers: columns)
+
+        from(query, where: exists(indexes_query))
+
+      {:without_index_covering, columns}, query ->
+        indexes_query =
+          PgClass.query(subquery: true, collate_indexes: true, index_covers: columns)
+
+        from(query, where: not exists(indexes_query))
+
       {field, value}, query ->
         apply_filter(query, field, value)
     end)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Endo.MixProject do
   def project do
     [
       app: :endo,
-      version: "0.1.13",
+      version: "0.1.14",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Endo has always supported the ability to list tables containing at least one index matching a given column(s) like so:

```elixir
Endo.list_tables(MyApp.Repo, with_column: "org_id", without_index: "org_id")
Endo.list_tables(MyApp.Repo, with_column: "org_id", with_column: "location_id", without_index: ["org_id", "location_id"])
```

However, `with_index` and `without_index` require exact matches for composite indexes, and ordering of fields matters (as composite indexes in Postgres use order to determine whether or not the query planner can actually use an index. Indexes will be usable if fields are constrained in order from left to right).

This PR introduces a new `with_index_covering` and `without_index_covering` options which tells Endo to look for tables containing at least one index which covers the given column(s) regardless of ordering. This means that a composite index `(org_id x location_id x patient_id)` will match `with_index_covering: "location_id"` and `with_index_covering: ["patient_id", "org_id"]` where `with_index` would only match if given exactly `["org_id", "location_id", "patient_id"]`.
