### PR TITLE
Expose underlying type information for columns, expose `:position` and `:default_value` on columns

### DIFF
--- a/lib/endo/adapters/postgres.ex
+++ b/lib/endo/adapters/postgres.ex
@@ -19,6 +19,7 @@ defmodule Endo.Adapters.Postgres do
   alias Endo.Adapters.Postgres.Size
   alias Endo.Adapters.Postgres.Table
   alias Endo.Adapters.Postgres.TableConstraint
+  alias Endo.Column.Postgres.Type
 
   @spec list_tables(repo :: module(), opts :: Keyword.t()) :: [Table.t()]
   def list_tables(repo, opts \\ []) when is_atom(repo) do
@@ -55,8 +56,8 @@ defmodule Endo.Adapters.Postgres do
     %Endo.Table{
       adapter: __MODULE__,
       name: table.table_name,
-      columns: Enum.map(table.columns, &to_endo/1),
       indexes: Enum.map(table.indexes, &to_endo/1),
+      columns: table.columns |> Enum.map(&to_endo/1) |> Enum.sort_by(& &1.position),
       schemas: %Endo.Schema.NotLoaded{
         table: table.table_name,
         otp_app: Keyword.get(config, :otp_app)
@@ -73,7 +74,10 @@ defmodule Endo.Adapters.Postgres do
     %Endo.Column{
       adapter: __MODULE__,
       name: column.column_name,
-      type: column.data_type
+      position: column.ordinal_position,
+      default_value: column.column_default,
+      type: column.data_type,
+      type_metadata: Type.Metadata.derive!(column)
     }
   end
 

--- a/lib/endo/column.ex
+++ b/lib/endo/column.ex
@@ -1,5 +1,64 @@
 defmodule Endo.Column do
   @moduledoc "Column metadata for a given table's columns"
   @type t :: %__MODULE__{}
-  defstruct [:adapter, :name, :type]
+  defstruct [:adapter, :name, :type, :position, :type_metadata, :default_value]
+
+  defmodule Postgres.Type.Metadata do
+    alias Endo.Adapters.Postgres
+
+    defmodule Character do
+      @moduledoc false
+      @type t :: %__MODULE__{}
+      defstruct [:character_length, :octet_length]
+    end
+
+    defmodule Numeric do
+      @moduledoc false
+      @type t :: %__MODULE__{}
+      defstruct [:precision, :radix, :scale]
+    end
+
+    defmodule DateTime do
+      @moduledoc false
+      @type t :: %__MODULE__{}
+      defstruct [:precision]
+    end
+
+    defmodule Interval do
+      @moduledoc false
+      @type t :: %__MODULE__{}
+      defstruct [:type, :precision]
+    end
+
+    @type t :: Character.t() | Numeric.t() | DateTime.t() | Interval.t()
+
+    @spec derive!(Postgres.Column.t()) :: t() | nil
+    def derive!(%Postgres.Column{} = column) when is_integer(column.character_maximum_length) do
+      %Character{
+        character_length: column.character_maximum_length,
+        octet_length: column.character_octet_length
+      }
+    end
+
+    def derive!(%Postgres.Column{} = column) when is_integer(column.numeric_precision) do
+      %Numeric{
+        precision: column.numeric_precision,
+        radix: column.numeric_precision_radix,
+        scale: column.numeric_scale
+      }
+    end
+
+    def derive!(%Postgres.Column{} = column) when is_binary(column.interval_type) do
+      %Interval{type: column.interval_type, precision: column.datetime_precision}
+    end
+
+    def derive!(%Postgres.Column{} = column) when is_integer(column.datetime_precision) do
+      %DateTime{precision: column.datetime_precision}
+    end
+
+    # coveralls-ignore-start
+    def derive!(_column) do
+      nil
+    end
+  end
 end

--- a/priv/repo/migrations/20221221123643_bootstrap_testing_env.exs
+++ b/priv/repo/migrations/20221221123643_bootstrap_testing_env.exs
@@ -33,6 +33,11 @@ defmodule Test.Postgres.Repo.Migrations.BootstrapTestingEnv do
     end
 
     create(unique_index(:repos, [:account_id, :name]))
+
+    execute("""
+      ALTER TABLE repos
+      ADD COLUMN some_interval INTERVAL MINUTE TO SECOND;
+    """)
   end
 
   defp create_orgs do

--- a/test/endo_test.exs
+++ b/test/endo_test.exs
@@ -354,6 +354,36 @@ defmodule EndoTest do
         assert value =~ "bytes" or value =~ "kB"
       end
     end
+
+    test "colum type metadata is returned alongside tables" do
+      assert %Endo.Table{columns: columns} = Endo.get_table(Test.Postgres.Repo, "repos")
+
+      assert %Endo.Column{
+               type_metadata: %Endo.Column.Postgres.Type.Metadata.Character{
+                 character_length: 255,
+                 octet_length: 1020
+               }
+             } = Enum.find(columns, &(&1.name == "description"))
+
+      assert %Endo.Column{
+               type_metadata: %Endo.Column.Postgres.Type.Metadata.Numeric{
+                 precision: 64,
+                 radix: 2,
+                 scale: 0
+               }
+             } = Enum.find(columns, &(&1.name == "id"))
+
+      assert %Endo.Column{
+               type_metadata: %Endo.Column.Postgres.Type.Metadata.DateTime{precision: 0}
+             } = Enum.find(columns, &(&1.name == "inserted_at"))
+
+      assert %Endo.Column{
+               type_metadata: %Endo.Column.Postgres.Type.Metadata.Interval{
+                 type: "MINUTE TO SECOND",
+                 precision: 6
+               }
+             } = Enum.find(columns, &(&1.name == "some_interval"))
+    end
   end
 
   describe "load_tables/1" do


### PR DESCRIPTION
Exposes additional column/column type metadata
