### PR TITLE
Surface user friendly column type names

### DIFF
--- a/lib/endo/adapters/postgres.ex
+++ b/lib/endo/adapters/postgres.ex
@@ -76,7 +76,7 @@ defmodule Endo.Adapters.Postgres do
       name: column.column_name,
       position: column.ordinal_position,
       default_value: column.column_default,
-      type: column.data_type,
+      type: column.udt_name,
       type_metadata: Type.Metadata.derive!(column)
     }
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Endo.MixProject do
   def project do
     [
       app: :endo,
-      version: "0.1.15",
+      version: "0.1.16",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/endo_test.exs
+++ b/test/endo_test.exs
@@ -77,10 +77,10 @@ defmodule EndoTest do
       assert Enum.count(schema_migrations.indexes) == 1
       assert Enum.count(schema_migrations.columns) == 2
 
-      assert %Endo.Column{name: "version", type: "bigint"} =
+      assert %Endo.Column{name: "version", type: "int8"} =
                ctx.find.(schema_migrations.columns, "version")
 
-      assert %Endo.Column{name: "inserted_at", type: "timestamp without time zone"} =
+      assert %Endo.Column{name: "inserted_at", type: "timestamp"} =
                ctx.find.(schema_migrations.columns, "inserted_at")
 
       assert %Endo.Index{name: "schema_migrations_pkey"} =


### PR DESCRIPTION
`jsonb` instead of `ARRAY`, `timestamp` instead of `timestamp without time zone` etc.