### PR TITLE
END 012/configurable table schema prefixes

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -107,7 +107,7 @@ alias Credo.Check
           {Check.Readability.SinglePipe, []},
           {Check.Readability.StrictModuleLayout, []},
           {Check.Readability.WithCustomTaggedTuple, []},
-          {Check.Refactor.ABCSize, [max_size: 60]},
+          {Check.Refactor.ABCSize, [max_size: 80]},
           {Check.Refactor.DoubleBooleanNegation, []},
           {Check.Refactor.FilterReject, []},
           {Check.Refactor.MapMap, []},

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 import Config
 
-config :endo, ecto_repos: [Test.Postgres.Repo]
+config :endo, ecto_repos: [Test.Postgres.Repo], table_schema: "public"
 
 config :endo, Test.Postgres.Repo,
   database: System.fetch_env!("POSTGRES_DB"),

--- a/lib/endo.ex
+++ b/lib/endo.ex
@@ -139,6 +139,29 @@ defmodule Endo do
 
   As features get built out, we make no hard guarantees of keeping the `metadata` field stable, but efforts will
   of course be taken to mitigate unnecessary breaking changes from occuring.
+
+  ## Setting schema prefixes / table schemas
+
+  By default, Endo will assume that your application's tables are stored in the `public` schema. This is the
+  default schema for Postgres, but it is possible to change this by setting the `:table_schema` config option
+  in your application's config like so:
+
+  ```elixir
+  config :endo, table_schema: "custom_schema"
+  ```
+
+  If set this way, Endo will use the given schema as the default schema for all queries. This can be overridden
+  on a per-query basis by passing the `:prefix` option to `Endo.list_tables/2` or `Endo.get_table/3` mimicing
+  the behavior of the `:prefix` option in `Ecto`:
+
+  ```elixir
+  [%Endo.Table{}, ...] = Endo.list_tables(MyApp.Repo, prefix: "custom_schema")
+  %Endo.Table{} = Endo.get_table(MyApp.Repo, "special_table", prefix: "custom_schema")
+  ```
+
+  Additionally, Endo will display the table schema of any given table via `%Endo.Table{schema: schema}`.
+
+  For runtime debugging, you can use the `Endo.table_schema/0` function to retrieve the current default schema.
   """
 
   alias Endo.Adapters.Postgres

--- a/lib/endo.ex
+++ b/lib/endo.ex
@@ -144,6 +144,12 @@ defmodule Endo do
   alias Endo.Adapters.Postgres
 
   @doc """
+  Returns the default table schema used by Endo if not otherwise specified.
+  """
+  @spec table_schema :: String.t()
+  def table_schema, do: Application.get_env(:endo, :table_schema, "public")
+
+  @doc """
   Given an Ecto Repo and a table name, tries to return an Endo Table or nil if said table does
   not exist.
 

--- a/lib/endo/adapters/postgres.ex
+++ b/lib/endo/adapters/postgres.ex
@@ -33,7 +33,8 @@ defmodule Endo.Adapters.Postgres do
 
       %Table{
         table
-        | size: repo.one(size),
+        | schema: opts[:prefix],
+          size: repo.one(size),
           pg_class: repo.one(metadata),
           indexes: repo.all(indexes)
       }
@@ -54,6 +55,7 @@ defmodule Endo.Adapters.Postgres do
   def to_endo(%Table{} = table, config) do
     %Endo.Table{
       adapter: __MODULE__,
+      schema: table.schema,
       name: table.table_name,
       indexes: Enum.map(table.indexes, &to_endo(&1, config)),
       columns: table.columns |> Enum.map(&to_endo(&1, config)) |> Enum.sort_by(& &1.position),

--- a/lib/endo/adapters/postgres.ex
+++ b/lib/endo/adapters/postgres.ex
@@ -23,12 +23,13 @@ defmodule Endo.Adapters.Postgres do
 
   @spec list_tables(repo :: module(), opts :: Keyword.t()) :: [Table.t()]
   def list_tables(repo, opts \\ []) when is_atom(repo) do
+    opts = Keyword.put_new(opts, :prefix, Endo.table_schema())
     preloads = [:columns, table_constraints: [:key_column_usage, :constraint_column_usage]]
 
     derive_preloads = fn %Table{table_name: name} = table ->
       indexes = PgClass.query(collate_indexes: true, relname: name)
       metadata = PgClass.query(relname: name, relkind: ~w(r t m f p))
-      size = Size.query(relname: name)
+      size = Size.query(relname: name, prefix: opts[:prefix])
 
       %Table{
         table

--- a/lib/endo/adapters/postgres/size.ex
+++ b/lib/endo/adapters/postgres/size.ex
@@ -3,8 +3,10 @@ defmodule Endo.Adapters.Postgres.Size do
 
   import Ecto.Query
 
-  @spec query([{:relname, String.t()}]) :: Ecto.Queryable.t()
-  def query(relname: relname) do
+  @spec query([{:relname, String.t()}, {:prefix, String.t()}]) :: Ecto.Queryable.t()
+  def query(opts) do
+    relname = Enum.join([opts[:prefix], opts[:relname]], ".")
+
     select(
       with_cte("virtual_table", "virtual_table",
         as:

--- a/lib/endo/adapters/postgres/table.ex
+++ b/lib/endo/adapters/postgres/table.ex
@@ -59,7 +59,7 @@ defmodule Endo.Adapters.Postgres.Table do
   @impl Endo.Queryable
   def query(base_query \\ base_query(), filters) do
     filters
-    |> Keyword.put_new(:prefix, "public")
+    |> Keyword.put_new(:prefix, Endo.table_schema())
     |> Enum.reduce(base_query, fn
       {:prefix, prefix}, query when is_binary(prefix) ->
         from(x in query, where: x.table_schema == ^prefix)

--- a/lib/endo/adapters/postgres/table.ex
+++ b/lib/endo/adapters/postgres/table.ex
@@ -53,12 +53,17 @@ defmodule Endo.Adapters.Postgres.Table do
 
   @impl Endo.Queryable
   def base_query do
-    from(x in __MODULE__, as: :self, where: x.table_schema == "public")
+    from(x in __MODULE__, as: :self)
   end
 
   @impl Endo.Queryable
   def query(base_query \\ base_query(), filters) do
-    Enum.reduce(filters, base_query, fn
+    filters
+    |> Keyword.put_new(:prefix, "public")
+    |> Enum.reduce(base_query, fn
+      {:prefix, prefix}, query when is_binary(prefix) ->
+        from(x in query, where: x.table_schema == ^prefix)
+
       {:with_column, column_name}, query ->
         from(query, where: exists(Column.query(subquery: true, column_name: column_name)))
 

--- a/lib/endo/adapters/postgres/table.ex
+++ b/lib/endo/adapters/postgres/table.ex
@@ -58,9 +58,7 @@ defmodule Endo.Adapters.Postgres.Table do
 
   @impl Endo.Queryable
   def query(base_query \\ base_query(), filters) do
-    filters
-    |> Keyword.put_new(:prefix, Endo.table_schema())
-    |> Enum.reduce(base_query, fn
+    Enum.reduce(filters, base_query, fn
       {:prefix, prefix}, query when is_binary(prefix) ->
         from(x in query, where: x.table_schema == ^prefix)
 

--- a/lib/endo/adapters/postgres/table.ex
+++ b/lib/endo/adapters/postgres/table.ex
@@ -49,6 +49,7 @@ defmodule Endo.Adapters.Postgres.Table do
     field(:indexes, :map, virtual: true)
     field(:pg_class, :map, virtual: true)
     field(:size, :map, virtual: true)
+    field(:schema, :string, virtual: true)
   end
 
   @impl Endo.Queryable

--- a/lib/endo/queryable.ex
+++ b/lib/endo/queryable.ex
@@ -34,6 +34,10 @@ defmodule Endo.Queryable do
   @callback query(base_query :: Ecto.Queryable.t(), Keyword.t()) :: Ecto.Queryable.t()
 
   @spec apply_filter(Ecto.Queryable.t(), field :: atom(), value :: any()) :: Ecto.Queryable.t()
+  def apply_filter(query, :prefix, value) do
+    from(x in query, prefix: ^value)
+  end
+
   def apply_filter(query, :preload, value) do
     from(x in query, preload: ^value)
   end

--- a/lib/endo/table.ex
+++ b/lib/endo/table.ex
@@ -4,6 +4,7 @@ defmodule Endo.Table do
   defstruct [
     :adapter,
     :name,
+    :schema,
     columns: [],
     associations: [],
     indexes: [],

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Endo.MixProject do
   def project do
     [
       app: :endo,
-      version: "0.1.19",
+      version: "0.1.20",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/priv/repo/migrations/20221221123643_bootstrap_testing_env.exs
+++ b/priv/repo/migrations/20221221123643_bootstrap_testing_env.exs
@@ -5,6 +5,20 @@ defmodule Test.Postgres.Repo.Migrations.BootstrapTestingEnv do
     create_accounts()
     create_repos()
     create_orgs()
+    create_prefix_table()
+  end
+
+  def create_prefix_table do
+    execute("CREATE SCHEMA debug")
+
+    flush()
+
+    create table(:events, prefix: "debug") do
+      add(:type, :string, null: false)
+      add(:data, :map, null: false)
+
+      timestamps()
+    end
   end
 
   defp create_accounts do

--- a/test/endo_test.exs
+++ b/test/endo_test.exs
@@ -63,7 +63,8 @@ defmodule EndoTest do
 
   describe "get_table/3 (Postgres)" do
     test "given valid table name and repo, returns Endo Table" do
-      assert %Endo.Table{name: "orgs"} = Endo.get_table(Test.Postgres.Repo, "orgs")
+      assert %Endo.Table{name: "orgs", schema: "public"} =
+               Endo.get_table(Test.Postgres.Repo, "orgs")
     end
 
     test "given invalid table name, but valid repo, returns nil" do
@@ -79,7 +80,7 @@ defmodule EndoTest do
     end
 
     test "returns table belonging to non-default prefix if specified correctly" do
-      assert %Endo.Table{name: "events"} =
+      assert %Endo.Table{name: "events", schema: "debug"} =
                Endo.get_table(Test.Postgres.Repo, "events", prefix: "debug")
     end
   end

--- a/test/endo_test.exs
+++ b/test/endo_test.exs
@@ -6,6 +6,19 @@ defmodule EndoTest do
     {:ok, find: fn tables, name -> Enum.find(tables, &(&1.name == name)) end}
   end
 
+  describe "table_schema/0" do
+    test "returns specified table schema" do
+      # If configured, return the configured value
+      assert :ok = Application.put_env(:endo, :table_schema, "a_custom_schema_prefix")
+      assert "a_custom_schema_prefix" = Endo.table_schema()
+
+      # TODO: Otherwise fall back to "public" which is the default in Postgres at least --
+      #       might need to investigate how we go about supporting this for future adapters.
+      assert :ok = Application.delete_env(:endo, :table_schema)
+      assert "public" = Endo.table_schema()
+    end
+  end
+
   describe "list_tables/2" do
     test "returns error when given non-ecto repo" do
       assert_raise(

--- a/test/endo_test.exs
+++ b/test/endo_test.exs
@@ -69,6 +69,19 @@ defmodule EndoTest do
     test "given invalid table name, but valid repo, returns nil" do
       assert is_nil(Endo.get_table(Test.Postgres.Repo, "passports"))
     end
+
+    test "returns nothing when querying table belonging to non-default prefix when not specified" do
+      assert is_nil(Endo.get_table(Test.Postgres.Repo, "events"))
+    end
+
+    test "returns nothing when querying table belonging to incorrectly specified prefix" do
+      assert is_nil(Endo.get_table(Test.Postgres.Repo, "events", prefix: "something_random"))
+    end
+
+    test "returns table belonging to non-default prefix if specified correctly" do
+      assert %Endo.Table{name: "events"} =
+               Endo.get_table(Test.Postgres.Repo, "events", prefix: "debug")
+    end
   end
 
   describe "list_tables/2 (Postgres)" do


### PR DESCRIPTION
Closes #15

- END-013 - Support setting schema in filters
- END-013 - Support setting schema via Endo configuration
- END-013 - Test for `Endo.table_schema/0`
- END-013 - Fixes and unit tests for querying table w/ schema prefixes
- END-013 - Expose schema in `Endo.Table.t()`
- END-013 - Add documentation
- END-013 - Bump version
