### PR TITLE
Add time outs to list_tables/2

### DIFF
--- a/lib/endo/adapters/postgres.ex
+++ b/lib/endo/adapters/postgres.ex
@@ -42,8 +42,8 @@ defmodule Endo.Adapters.Postgres do
 
     opts
     |> Table.query()
-    |> repo.all()
-    |> Task.async_stream(&(&1 |> repo.preload(preloads) |> derive_preloads.()))
+    |> repo.all(timeout: :timer.minutes(2))
+    |> Task.async_stream(&(&1 |> repo.preload(preloads) |> derive_preloads.()), timeout: :timer.minutes(2))
     |> Enum.map(fn {:ok, %Table{} = table} -> table end)
   end
 


### PR DESCRIPTION
When running some tests on my mass deduplication job, I noticed we were getting some timeouts from Endo. This seems to solve the issue.