### PR TITLE
replace docker-compose with docker compose in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,6 @@ jobs:
           key: ${{ hashFiles('mix.lock') }}-${{ matrix.elixir }}-${{ matrix.otp }}
       - if: steps.mix-cache.outputs.cache-hit != 'true'
         run: mkdir -p priv/plts; mix deps.get; mix deps.compile
-      - run: docker-compose up -d
+      - run: docker compose up -d
       - run: mix lint
       - run: MIX_ENV=test mix do ecto.create, ecto.migrate, test


### PR DESCRIPTION
`docker-compose` was deprecated in favor of `docker compose`. This should fix the `lint-and-test` job during ci.