### PR TITLE
END 015/optionally run preload derivation synchronously

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -137,6 +137,7 @@ alias Credo.Check
 
           ## Incompatible with modern versions of Elixir -----------------------
           {Check.Refactor.MapInto, []},
+          {Check.Refactor.ModuleDependencies, []},
           {Check.Warning.LazyLogging, []}
         ]
       }

--- a/lib/endo.ex
+++ b/lib/endo.ex
@@ -162,6 +162,23 @@ defmodule Endo do
   Additionally, Endo will display the table schema of any given table via `%Endo.Table{schema: schema}`.
 
   For runtime debugging, you can use the `Endo.table_schema/0` function to retrieve the current default schema.
+
+  ## Testing and asynchronous operations
+
+  Intermittent or even consistent unit test failures may occur, depending on certain database operations which
+  occur simultaneously during execution, given that `Endo.get_table/3` and `Endo.list_tabes/2` spawn their
+  own processes under-the-hood. It is not uncommon to run into database connection errors in your test environment.
+  To avoid this, or to force these functions to run synchronously, simply add the following in your application's config:
+
+  ```elixir
+  config :endo, async: false
+  ```
+
+  or, if you prefer to keep things isolated:
+
+  ```elixir
+  Endo.list_tables(Repo, async: false)
+  ```
   """
 
   alias Endo.Adapters.Postgres

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Endo.MixProject do
   def project do
     [
       app: :endo,
-      version: "0.1.23",
+      version: "0.1.24",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/endo_test.exs
+++ b/test/endo_test.exs
@@ -83,6 +83,11 @@ defmodule EndoTest do
       assert %Endo.Table{name: "events", schema: "debug"} =
                Endo.get_table(Test.Postgres.Repo, "events", prefix: "debug")
     end
+
+    test "given `async: false` option, derives preloads synchronously and returns table" do
+      assert %Endo.Table{name: "orgs", schema: "public"} =
+               Endo.get_table(Test.Postgres.Repo, "orgs", async: false)
+    end
   end
 
   describe "list_tables/2 (Postgres)" do


### PR DESCRIPTION
`get_tables` and `list_tables` load preloads asynchronously, sporadically (sometimes consistently if other db operations are occurring simultaneously) causing connection errors on a sandbox db, thus causing test failures. This change allows users to pass `async: false` to the function directly _or_  simply add `config :endo, async: false` to their config/test.exs file.